### PR TITLE
feat(nested-battle-menu): Adds a nested battle menu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-run = "tactics-exploration"
 [dependencies]
 anyhow = "1.0.100"
 bevy = { version = "0.17.3" }
-bevy-inspector-egui = "0.35.0"
+bevy-inspector-egui = { version = "0.35" }
 bevy_common_assets = { version = "0.14.0", features = ["json"] }
 bevy_ecs_tiled = { version = "0.10.0", features = ["debug"] }
 bevy_ecs_tilemap = "0.17.0"

--- a/devlog.md
+++ b/devlog.md
@@ -13,7 +13,7 @@ I like keep tracking of what I think I need to do in a list. For now, this track
   - [ ] Damage / AP Calculations?
   - [ ] Multiple Types of Moves?
   - [ ] Allow the unit to pick a FacedDirection on Wait
-  - [ ] UI Support for more complex choices of "actions"?
+  - [x] UI Support for more complex choices of "actions"?
 
 - [ ] Animation Data
   - [ ] Update derived animation data to populate expected texture atlas indices
@@ -46,6 +46,12 @@ I like keep tracking of what I think I need to do in a list. For now, this track
 - [ ] Ensure assets are loaded before moving to new scene
 - [ ] Sometimes there are weird lines running through the fonts?
 - [ ] Downed Characters should not be allowed to attack lol
+- [ ] The UI should have "greyed out" options if they can't be taken
+- [ ] Despawn the MainMenu (and anything else associated with the state) when we go into the BattleState
+- [ ] If the Battle ends, but a player happens to have an open menu, the player can still move cursor on menu as it's an "ActiveMenu"
+- [ ] Players can still do stuff with a unit after they've "waited"
+- [ ] Players can still act after they've waited
+- [ ] If you end the phase with a menu open (or maybe between messaging frames?) things can get pretty bad.
 
 ## Archive
 

--- a/src/battle_menu.rs
+++ b/src/battle_menu.rs
@@ -7,490 +7,810 @@ use leafwing_input_manager::prelude::ActionState;
 
 use crate::{
     assets::FontResource,
-    battle::{BattleEntity, UnitCommand, UnitSelectionMessage, UnitUiCommandMessage},
+    battle::{
+        BattleEntity, UnitCommand, UnitSelectionBackMessage, UnitSelectionMessage,
+        UnitUiCommandMessage,
+    },
     battle_phase::UnitPhaseResources,
+    combat::skills,
     grid::{self, GridManagerResource},
     grid_cursor::Cursor,
-    menu::{
-        menu_navigation::{ActiveMenu, GameMenuController, GameMenuGrid},
-        ui_consts::NORMAL_MENU_BUTTON_COLOR,
-    },
+    menu::menu_navigation::{ActiveMenu, GameMenuController, GameMenuGrid},
     player::{self, Player, PlayerInputAction},
     unit::Unit,
 };
 
-pub const UI_BACKGROUND: Color = Color::linear_rgba(0.2, 0.2, 0.2, 0.7);
+pub const UI_BACKGROUND: Color = Color::linear_rgba(0.84, 0.79, 0.72, 1.0);
+pub const UI_BUTTON_BACKGROUND: Color = Color::linear_rgba(0.74, 0.69, 0.62, 1.0);
+pub const UI_HEADER_BACKGROUND: Color = Color::linear_rgba(0.64, 0.59, 0.52, 1.0);
 
+/// A marker component for the "Standard Battle UI", or the first menu of the Player's battle menu
 #[derive(Component)]
 pub struct BattlePlayerUI {}
 
+/// A marker component for the container that holds the information about the unit under the player's cursor
 #[derive(Component)]
 pub struct PlayerUiInfo {}
 
+/// A marker component for the text that displays the units health underneath the player's cursor
 #[derive(Component)]
 pub struct PlayerUiHealthText {}
 
+/// A marker component for the text that displays the units name underneath the player's cursor
 #[derive(Component)]
 pub struct PlayerUiNameText {}
 
-#[derive(Component)]
-pub enum UnitMenuAction {
-    Move,
-    Attack,
-    Wait,
-}
-
+/// A marker component for the Objective UI
 #[derive(Component)]
 pub struct ObjectiveUi {}
+
+/// A marker component for the text in the ObjectiveUI
 #[derive(Component)]
 pub struct ObjectiveText {}
 
-pub fn build_top_ui(commands: &mut Commands, fonts: &FontResource) {
-    let ui_top_space = commands
-        .spawn((
-            Node {
-                align_self: AlignSelf::FlexStart,
-                height: percent(15),
-                width: percent(100),
-                align_items: AlignItems::FlexEnd,
-                flex_direction: FlexDirection::Column,
-                padding: UiRect::top(percent(5)).with_right(percent(5)),
-                ..Default::default()
-            },
-            BattleEntity {},
-        ))
-        .id();
+/// Marker component for the top level BattleUiContainer.
+///
+/// It's expected that the BattleUiContainer will house the
+#[derive(Component)]
+pub struct BattleUiContainer {}
 
-    let objective_ui = commands
-        .spawn((
-            Node {
-                height: percent(100),
-                width: percent(15),
-                align_content: AlignContent::Center,
-                align_items: AlignItems::Center,
-                justify_content: JustifyContent::Center,
-                ..Default::default()
-            },
-            BackgroundColor(UI_BACKGROUND),
-            ObjectiveUi {},
-            BorderRadius::all(percent(20)),
-            children![(
-                Text("Defeat all Enemies".to_string()),
-                ObjectiveText {},
-                TextFont {
-                    font: fonts.fine_fantasy.clone(),
-                    ..Default::default()
-                }
-            )],
-        ))
-        .id();
+/// Marker component for the third tier of the Battle Menu
+#[derive(Component)]
+pub struct SkillsFilteredByCategoryMenu {}
 
-    commands.entity(ui_top_space).add_child(objective_ui);
+/// Marker component for the second tier of the Battle Menu
+#[derive(Component)]
+pub struct SkillMenu {}
+
+/// Marker component for buttons in menus that potentially should get despawned
+/// when a menu is removed.
+#[derive(Component)]
+pub struct BattleButton {}
+
+/// An action to take when the Component is interacted with.
+///
+/// Typically a part of a button on a Button
+#[derive(Component, Clone)]
+pub enum BattleMenuAction {
+    Action(UnitMenuAction),
+    OpenSkillMenu,
+    OpenSkillsFilteredByCategoryMenu(skills::SkillCategoryId),
 }
 
-pub fn battle_ui_setup(mut commands: Commands, fonts: Res<FontResource>) {
-    let bottom_ui = commands
-        .spawn((Node {
-            align_self: AlignSelf::FlexEnd,
-            height: percent(20),
-            width: percent(100),
-            align_items: AlignItems::Center,
-            justify_content: JustifyContent::SpaceEvenly,
-            ..Default::default()
-        },))
-        .id();
+/// A terminal node in the BattleMenu. Turned into a `UnitCommand` and sent out
+/// as an Event.
+#[derive(Component, PartialEq, Eq, Clone)]
+pub enum UnitMenuAction {
+    Move,
+    Attack,
+    UseSkill(skills::SkillId),
+    Wait,
+}
 
-    let player_ui_1 = build_player_ui(&mut commands, &fonts, Player::One);
-    let player_ui_2 = build_player_ui(&mut commands, &fonts, Player::Two);
+/// Functions for spawning the battle UI itself
+///
+/// Includes the definition of the Battle Menus, PlayerUI, and the ObjectiveUI.
+pub mod battle_menu_ui_definition {
+    use super::*;
 
-    commands
-        .entity(bottom_ui)
-        .add_children(&[player_ui_1, player_ui_2]);
+    /// Setup the Battle UI! Intended to run OnEnter(GameState::Battle)
+    pub fn battle_ui_setup(mut commands: Commands, fonts: Res<FontResource>) {
+        build_battle_grid_ui(&mut commands, &fonts);
+        build_top_ui(&mut commands, &fonts);
+    }
 
-    let mut battle_ui_node = commands.spawn((
+    fn build_top_ui(commands: &mut Commands, fonts: &FontResource) {
+        let ui_top_space = commands
+            .spawn((
+                Node {
+                    align_self: AlignSelf::FlexStart,
+                    height: percent(15),
+                    width: percent(100),
+                    align_items: AlignItems::FlexEnd,
+                    flex_direction: FlexDirection::Column,
+                    padding: UiRect::top(percent(5)).with_right(percent(5)),
+                    ..Default::default()
+                },
+                BattleEntity {},
+            ))
+            .id();
+
+        let objective_ui = commands
+            .spawn((
+                Node {
+                    height: percent(100),
+                    width: percent(25),
+                    align_content: AlignContent::Center,
+                    align_items: AlignItems::Center,
+                    justify_content: JustifyContent::Center,
+                    ..Default::default()
+                },
+                BackgroundColor(UI_BACKGROUND),
+                ObjectiveUi {},
+                BorderRadius::all(percent(20)),
+                children![(
+                    Text("Defeat all Enemies".to_string()),
+                    TextColor(Color::BLACK),
+                    ObjectiveText {},
+                    TextFont {
+                        font: fonts.badge.clone(),
+                        ..Default::default()
+                    }
+                )],
+            ))
+            .id();
+
+        commands.entity(ui_top_space).add_child(objective_ui);
+    }
+
+    fn build_battle_grid_ui(commands: &mut Commands, fonts: &FontResource) {
+        let top_level_battle_grid_container = commands
+            .spawn((
+                Name::new("BattleUI"),
+                Node {
+                    display: Display::Grid,
+                    width: percent(100),
+                    height: percent(100),
+                    grid_template_rows: vec![
+                        // Top Menu
+                        GridTrack::flex(0.2),
+                        // Battle Space
+                        GridTrack::flex(0.6),
+                        // Bottom Menu
+                        GridTrack::flex(0.2),
+                    ],
+                    grid_template_columns: vec![
+                        GridTrack::flex(0.1),
+                        // User Menu 1
+                        GridTrack::flex(0.35),
+                        GridTrack::flex(0.1),
+                        // User Menu 2
+                        GridTrack::flex(0.35),
+                        GridTrack::flex(0.1),
+                    ],
+                    ..Default::default()
+                },
+                BattleEntity {},
+            ))
+            .id();
+
+        // TODO: Formalize this into some data representation somewhere? Probably dependent on the configuration of players...
+        let player_offsets = [(3, 2, Player::One), (3, 4, Player::Two)];
+        for player_offset in player_offsets {
+            let player_ui_container = commands
+                .spawn((
+                    Name::new("PlayerUiContainer"),
+                    Node {
+                        display: Display::Grid,
+                        width: percent(100),
+                        height: percent(100),
+                        grid_template_rows: vec![
+                            // One row in the Battle Menu for now
+                            GridTrack::flex(1.0),
+                        ],
+                        grid_template_columns: vec![GridTrack::flex(0.3), GridTrack::flex(0.7)],
+                        grid_row: GridPlacement::span(1).set_start(player_offset.0),
+                        grid_column: GridPlacement::span(1).set_start(player_offset.1),
+                        padding: UiRect::bottom(percent(2)),
+                        ..Default::default()
+                    },
+                    BorderRadius::all(percent(5)),
+                ))
+                .id();
+
+            // Build Player Unit UI Info
+            let player_ui_info = commands
+                .spawn((
+                    PlayerUiInfo {},
+                    BackgroundColor(UI_BACKGROUND),
+                    Node {
+                        height: percent(100),
+                        width: percent(100),
+                        flex_direction: FlexDirection::Column,
+                        justify_content: JustifyContent::Center,
+                        align_items: AlignItems::FlexStart,
+                        padding: UiRect {
+                            left: percent(5),
+                            ..Default::default()
+                        },
+                        grid_column: GridPlacement::span(1).set_start(1),
+                        ..Default::default()
+                    },
+                    Visibility::Hidden,
+                    player_offset.2,
+                ))
+                .id();
+
+            let font_style = TextFont {
+                font: fonts.fine_fantasy.clone(),
+                font_size: 24.,
+                font_smoothing: bevy::text::FontSmoothing::None,
+                ..Default::default()
+            };
+
+            let health_text = commands
+                .spawn((
+                    Text::new("Health"),
+                    PlayerUiHealthText {},
+                    font_style.clone(),
+                    TextColor(Color::BLACK),
+                ))
+                .id();
+            let name_text = commands
+                .spawn((
+                    Text::new("Unit Name"),
+                    PlayerUiNameText {},
+                    font_style.clone().with_font(fonts.badge.clone()),
+                    TextColor(Color::BLACK),
+                ))
+                .id();
+            let ap_text = commands
+                .spawn((
+                    Text::new("AP"),
+                    PlayerUiApText {},
+                    font_style.clone(),
+                    TextColor(Color::BLACK),
+                ))
+                .id();
+            let move_text = commands
+                .spawn((
+                    Text::new("Move"),
+                    PlayerUiMoveText {},
+                    font_style.clone(),
+                    TextColor(Color::BLACK),
+                ))
+                .id();
+
+            let action_category_menu = commands
+                .spawn((
+                    Name::new("ActionCategoryMenu"),
+                    Node {
+                        width: percent(100),
+                        height: percent(100),
+                        flex_direction: FlexDirection::Column,
+                        justify_content: JustifyContent::SpaceEvenly,
+                        align_items: AlignItems::FlexStart,
+                        grid_column: GridPlacement::start(2).set_end(4),
+                        grid_row: GridPlacement::start(1).set_end(-1),
+                        padding: UiRect::left(percent(1)),
+                        ..Default::default()
+                    },
+                    BackgroundColor(UI_BACKGROUND),
+                    Visibility::Hidden,
+                    BorderRadius::right(percent(5)),
+                    player_offset.2,
+                    ZIndex(1),
+                    BoxShadow::new(Color::BLACK, percent(-2), px(0), percent(0), percent(2)),
+                    SkillMenu {},
+                ))
+                .id();
+
+            // Build Battle UI
+            let battle_menu_container = commands
+                .spawn((
+                    Name::new("PlayerBattleMenu"),
+                    Node {
+                        display: Display::Grid,
+                        width: percent(100),
+                        height: percent(100),
+                        grid_column: GridPlacement::span(1).set_start(2),
+                        grid_template_columns: vec![RepeatedGridTrack::flex(4, 0.25)],
+                        ..Default::default()
+                    },
+                    Visibility::Hidden,
+                    BattleUiContainer {},
+                    player_offset.2,
+                ))
+                .id();
+
+            let move_button = commands
+                .spawn(battle_ui_button(
+                    fonts,
+                    BattleMenuAction::Action(UnitMenuAction::Move),
+                    "Move",
+                ))
+                .id();
+
+            let skills_button = commands
+                .spawn(battle_ui_button(
+                    fonts,
+                    BattleMenuAction::OpenSkillMenu,
+                    "Skills",
+                ))
+                .id();
+
+            let wait_button = commands
+                .spawn(battle_ui_button(
+                    fonts,
+                    BattleMenuAction::Action(UnitMenuAction::Wait),
+                    "Wait",
+                ))
+                .id();
+
+            let mut menu = GameMenuGrid::new_vertical();
+            menu.push_buttons_to_stack(&[move_button, skills_button, wait_button]);
+
+            let standard_battle_menu_container = commands
+                .spawn((
+                    Name::new("StandardBattleMenuTab"),
+                    Node {
+                        width: percent(100),
+                        height: percent(100),
+                        flex_direction: FlexDirection::Column,
+                        justify_content: JustifyContent::SpaceEvenly,
+                        align_items: AlignItems::FlexStart,
+                        grid_column: GridPlacement::start(1).set_end(3),
+                        grid_row: GridPlacement::start(1).set_end(-1),
+                        padding: UiRect::left(percent(1)),
+                        ..Default::default()
+                    },
+                    GameMenuController {
+                        players: HashSet::from([player_offset.2]),
+                    },
+                    menu,
+                    BattlePlayerUI {},
+                    Visibility::Hidden,
+                    BorderRadius::right(percent(5)),
+                    player_offset.2,
+                    BackgroundColor(UI_BACKGROUND),
+                    BoxShadow::new(Color::BLACK, percent(-0.5), px(0), percent(0), percent(2)),
+                ))
+                .id();
+
+            let action_menu = commands
+                .spawn((
+                    Name::new("ActionMenu"),
+                    Node {
+                        width: percent(100),
+                        height: percent(100),
+                        flex_direction: FlexDirection::Column,
+                        justify_content: JustifyContent::SpaceEvenly,
+                        align_items: AlignItems::FlexStart,
+                        grid_column: GridPlacement::start(3).set_end(-1),
+                        grid_row: GridPlacement::start(1).set_end(-1),
+                        padding: UiRect::left(percent(1)),
+                        ..Default::default()
+                    },
+                    BackgroundColor(UI_BACKGROUND),
+                    BoxShadow::new(Color::BLACK, percent(-2), px(0), percent(0), percent(2)),
+                    Visibility::Hidden,
+                    BorderRadius::right(percent(5)),
+                    player_offset.2,
+                    ZIndex(2),
+                    SkillsFilteredByCategoryMenu {},
+                ))
+                .id();
+
+            commands
+                .entity(standard_battle_menu_container)
+                .add_children(&[move_button, skills_button, wait_button]);
+
+            commands.entity(battle_menu_container).add_children(&[
+                standard_battle_menu_container,
+                action_category_menu,
+                action_menu,
+            ]);
+
+            commands.entity(player_ui_info).add_children(&[
+                name_text,
+                health_text,
+                ap_text,
+                move_text,
+            ]);
+
+            commands
+                .entity(player_ui_container)
+                .add_children(&[player_ui_info, battle_menu_container]);
+
+            commands
+                .entity(top_level_battle_grid_container)
+                .add_child(player_ui_container);
+        }
+    }
+}
+
+// Returns an opaque Button Bundle to spawn for a BattleUiButton
+fn battle_ui_button(fonts: &FontResource, action: BattleMenuAction, text: &str) -> impl Bundle {
+    (
+        BackgroundColor(UI_BACKGROUND),
+        BorderColor::all(Color::BLACK),
+        BorderRadius::all(percent(5)),
+        Button,
         Node {
             width: percent(100),
-            height: percent(100),
+            height: percent(30),
+            justify_content: JustifyContent::FlexStart,
+            justify_items: JustifyItems::Center,
             align_items: AlignItems::Center,
-            justify_content: JustifyContent::Center,
+            border: UiRect::all(percent(0.5)),
+            padding: UiRect::left(percent(1)),
             ..Default::default()
         },
-        BattleEntity {},
-    ));
-
-    battle_ui_node.add_child(bottom_ui);
-    build_top_ui(&mut commands, &fonts);
-}
-
-fn player_ui_info_style() -> Node {
-    Node {
-        height: percent(100),
-        width: percent(35),
-        flex_direction: FlexDirection::Column,
-        justify_content: JustifyContent::Center,
-        align_items: AlignItems::FlexStart,
-        padding: UiRect {
-            left: percent(5),
-            ..Default::default()
-        },
-        ..Default::default()
-    }
-}
-
-fn build_player_ui_info(commands: &mut Commands, fonts: &FontResource, player: Player) -> Entity {
-    let player_ui_info = commands
-        .spawn((
-            PlayerUiInfo {},
-            player_ui_info_style(),
-            Visibility::Hidden,
-            player.clone(),
-        ))
-        .id();
-
-    let font_style = TextFont {
-        font: fonts.fine_fantasy.clone(),
-        ..Default::default()
-    };
-
-    let health_text = commands
-        .spawn((
-            Text::new("Health"),
-            PlayerUiHealthText {},
-            font_style.clone(),
-        ))
-        .id();
-    let name_text = commands
-        .spawn((
-            Text::new("Unit Name"),
-            PlayerUiNameText {},
-            font_style.clone(),
-        ))
-        .id();
-    let ap_text = commands
-        .spawn((Text::new("AP"), PlayerUiApText {}, font_style.clone()))
-        .id();
-    let move_text = commands
-        .spawn((Text::new("Move"), PlayerUiMoveText {}, font_style.clone()))
-        .id();
-
-    commands
-        .entity(player_ui_info)
-        .add_children(&[name_text, health_text, ap_text, move_text]);
-
-    player_ui_info
-}
-
-fn battle_menu_button_font(font: Handle<Font>) -> TextFont {
-    let button_text_font = TextFont {
-        font_size: 15.0,
-        font,
-        ..Default::default()
-    };
-    button_text_font
-}
-
-fn player_ui_button_style() -> Node {
-    Node {
-        width: percent(70),
-        height: percent(20),
-        justify_content: JustifyContent::Center,
-        align_items: AlignItems::Center,
-        border: UiRect::all(percent(2)),
-        ..Default::default()
-    }
-}
-
-fn build_battle_menu(commands: &mut Commands, fonts: &FontResource, player: Player) -> Entity {
-    let player_ui_battle_menu_style = Node {
-        height: percent(100),
-        width: percent(65),
-        flex_direction: FlexDirection::Column,
-        justify_content: JustifyContent::SpaceEvenly,
-        align_items: AlignItems::Center,
-        ..Default::default()
-    };
-
-    let move_button = commands
-        .spawn((
-            BorderColor::all(NORMAL_MENU_BUTTON_COLOR),
-            BorderRadius::all(percent(25)),
-            Button,
-            player_ui_button_style(),
-            player,
-            BackgroundColor(NORMAL_MENU_BUTTON_COLOR),
-            UnitMenuAction::Move,
-            children![(
-                Text::new("Move"),
-                battle_menu_button_font(fonts.fine_fantasy.clone()),
-                TextColor(Color::srgb(0.9, 0.9, 0.9))
-            )],
-        ))
-        .id();
-
-    let attack_button = commands
-        .spawn((
-            BorderColor::all(NORMAL_MENU_BUTTON_COLOR),
-            BorderRadius::all(percent(25)),
-            Button,
-            player_ui_button_style(),
-            player,
-            BackgroundColor(NORMAL_MENU_BUTTON_COLOR),
-            UnitMenuAction::Attack,
-            children![(
-                Text::new("Attack"),
-                battle_menu_button_font(fonts.fine_fantasy.clone()),
-                TextColor(Color::srgb(0.9, 0.9, 0.9))
-            )],
-        ))
-        .id();
-
-    let wait_button = commands
-        .spawn((
-            BorderColor::all(NORMAL_MENU_BUTTON_COLOR),
-            BorderRadius::all(percent(25)),
-            Button,
-            player_ui_button_style(),
-            player,
-            BackgroundColor(NORMAL_MENU_BUTTON_COLOR),
-            UnitMenuAction::Wait,
-            children![(
-                Text::new("Wait"),
-                battle_menu_button_font(fonts.fine_fantasy.clone()),
-                TextColor(Color::srgb(0.9, 0.9, 0.9))
-            )],
-        ))
-        .id();
-
-    let mut menu = GameMenuGrid::new_vertical();
-    menu.push_button_to_stack(move_button);
-    menu.push_button_to_stack(attack_button);
-    menu.push_button_to_stack(wait_button);
-
-    let player_ui_battle_menu = commands
-        .spawn((
-            Name::new(format!("Player {:?}'s Battle UI", player)),
-            player_ui_battle_menu_style.clone(),
-            GameMenuController {
-                players: HashSet::from([player]),
+        action,
+        BattleButton {},
+        children![(
+            Text::new(text),
+            TextFont {
+                font_size: 20.0,
+                font: fonts.badge.clone(),
+                font_smoothing: bevy::text::FontSmoothing::None,
+                ..Default::default()
             },
-            menu,
-            BackgroundColor(UI_BACKGROUND),
-            BattlePlayerUI {},
-            Visibility::Hidden,
-            BorderRadius::right(percent(25)),
-            player,
-        ))
-        .id();
-    commands
-        .entity(player_ui_battle_menu)
-        .add_children(&[move_button, attack_button, wait_button]);
-
-    player_ui_battle_menu
+            TextColor(Color::BLACK)
+        )],
+    )
 }
 
-fn build_player_ui(commands: &mut Commands, fonts: &FontResource, player: Player) -> Entity {
-    let player_ui_node = Node {
-        height: percent(100),
-        width: percent(30),
-        align_items: AlignItems::Center,
-        justify_content: JustifyContent::Center,
-        margin: UiRect {
-            left: percent(5),
-            right: percent(5),
-            ..Default::default()
-        },
-        ..Default::default()
-    };
-
-    let player_ui_node = commands
-        .spawn((
-            Name::new(format!("Player {:?} UI", player)),
-            BackgroundColor(UI_BACKGROUND),
-            player_ui_node.clone(),
-            BorderRadius::all(percent(25)),
-        ))
-        .id();
-
-    let player_ui_info = build_player_ui_info(commands, fonts, player);
-    let player_ui_battle_menu = build_battle_menu(commands, fonts, player);
-
-    commands
-        .entity(player_ui_node)
-        .add_children(&[player_ui_info, player_ui_battle_menu]);
-
-    player_ui_node
-}
-
-pub trait TextFromUnit: Component {
-    fn derive_text(unit: &Unit) -> String;
-
-    fn update(unit: &Unit, to_update: &mut Text) {
-        to_update.0 = Self::derive_text(unit);
-    }
-}
-
-impl TextFromUnit for PlayerUiHealthText {
-    fn derive_text(unit: &Unit) -> String {
-        format!("HP: {}/{}", unit.stats.health, unit.stats.max_health)
-    }
-}
-
-impl TextFromUnit for PlayerUiNameText {
-    fn derive_text(unit: &Unit) -> String {
-        unit.name.clone()
-    }
-}
-
+/// Marker component for the text that represents how much AP is left in the PlayerCursorInformationUI
 #[derive(Component)]
 pub struct PlayerUiApText {}
 
+/// Marker component for the text that represents how much Move is left in the PlayerCursorInformationUI
 #[derive(Component)]
 pub struct PlayerUiMoveText {}
 
-// TODO: Can I do Changed<GridPosition> or Changed<Unit> in two diff queries?
-pub fn update_player_ui_info(
-    grid_manager: Res<grid::GridManagerResource>,
-    cursor_query: Query<(&player::Player, &grid::GridPosition), With<Cursor>>,
-    unit_query: Query<(&Unit, &UnitPhaseResources)>,
-    // TODO: This is terrible. I could make this one Text box, or
-    // could do Option<Component> and have one query and then
-    // do some match / runtime stuff? Def a little silly.
-    mut player_unit_ui: Query<(&player::Player, &mut Visibility, &Children), With<PlayerUiInfo>>,
-    mut player_ui_health_text: Query<
-        &mut Text,
-        (
-            With<PlayerUiHealthText>,
-            Without<PlayerUiNameText>,
-            Without<PlayerUiApText>,
-            Without<PlayerUiMoveText>,
-        ),
-    >,
-    mut player_ui_name_text: Query<
-        &mut Text,
-        (
-            With<PlayerUiNameText>,
-            Without<PlayerUiHealthText>,
-            Without<PlayerUiApText>,
-            Without<PlayerUiMoveText>,
-        ),
-    >,
-    mut player_ui_move_text: Query<
-        &mut Text,
-        (
-            With<PlayerUiApText>,
-            Without<PlayerUiHealthText>,
-            Without<PlayerUiMoveText>,
-            Without<PlayerUiNameText>,
-        ),
-    >,
-    mut player_ui_ap_text: Query<
-        &mut Text,
-        (
-            With<PlayerUiMoveText>,
-            Without<PlayerUiHealthText>,
-            Without<PlayerUiApText>,
-            Without<PlayerUiNameText>,
-        ),
-    >,
-) {
-    for (cursor_player, grid_pos) in cursor_query.iter() {
-        let Some(entities) = grid_manager.grid_manager.get_by_position(grid_pos) else {
-            continue;
-        };
+/// Systems that update information on the Player Cursor Information UI
+pub mod player_info_ui_systems {
+    use super::*;
 
-        let unit = entities
-            .iter()
-            .filter_map(|t| unit_query.get(*t).ok())
-            .next();
-
-        for (ui_player, mut unit_ui_repr, children) in player_unit_ui.iter_mut() {
-            if cursor_player != ui_player {
-                continue;
-            }
-
-            match unit {
-                Some(..) => *unit_ui_repr = Visibility::Visible,
-                None => *unit_ui_repr = Visibility::Hidden,
-            };
-
-            // If there is a unit, we need to update the now visible UI
-            let Some((unit, phase_resources)) = unit else {
+    /// Updates the PlayerUiInfo pane based on the current position of the player's cursor.
+    pub fn update_player_ui_info(
+        grid_manager: Res<grid::GridManagerResource>,
+        // TODO: Can I do (Changed<GridPosition> or Changed<Unit>) in two diff queries?
+        cursor_query: Query<(&player::Player, &grid::GridPosition), With<Cursor>>,
+        unit_query: Query<(&Unit, &UnitPhaseResources)>,
+        // TODO: This is terrible. I could make this one Text box, or
+        // could do Option<Component> and have one query and then
+        // do some match / runtime stuff? Def a little silly.
+        mut player_unit_ui: Query<
+            (&player::Player, &mut Visibility, &Children),
+            With<PlayerUiInfo>,
+        >,
+        mut player_ui_health_text: Query<
+            &mut Text,
+            (
+                With<PlayerUiHealthText>,
+                Without<PlayerUiNameText>,
+                Without<PlayerUiApText>,
+                Without<PlayerUiMoveText>,
+            ),
+        >,
+        mut player_ui_name_text: Query<
+            &mut Text,
+            (
+                With<PlayerUiNameText>,
+                Without<PlayerUiHealthText>,
+                Without<PlayerUiApText>,
+                Without<PlayerUiMoveText>,
+            ),
+        >,
+        mut player_ui_move_text: Query<
+            &mut Text,
+            (
+                With<PlayerUiApText>,
+                Without<PlayerUiHealthText>,
+                Without<PlayerUiMoveText>,
+                Without<PlayerUiNameText>,
+            ),
+        >,
+        mut player_ui_ap_text: Query<
+            &mut Text,
+            (
+                With<PlayerUiMoveText>,
+                Without<PlayerUiHealthText>,
+                Without<PlayerUiApText>,
+                Without<PlayerUiNameText>,
+            ),
+        >,
+    ) {
+        for (cursor_player, grid_pos) in cursor_query.iter() {
+            let Some(entities) = grid_manager.grid_manager.get_by_position(grid_pos) else {
                 continue;
             };
 
-            for child in children {
-                if let Some(mut text) = player_ui_health_text.get_mut(*child).ok() {
-                    text.0 = PlayerUiHealthText::derive_text(&unit);
-                } else if let Some(mut text) = player_ui_name_text.get_mut(*child).ok() {
-                    text.0 = PlayerUiNameText::derive_text(&unit);
-                } else if let Some(mut text) = player_ui_move_text.get_mut(*child).ok() {
-                    text.0 = format!("Move: {}", phase_resources.movement_points_left_in_phase);
-                } else if let Some(mut text) = player_ui_ap_text.get_mut(*child).ok() {
-                    text.0 = format!("AP: {}", phase_resources.action_points_left_in_phase);
+            let unit = entities
+                .iter()
+                .filter_map(|t| unit_query.get(*t).ok())
+                .next();
+
+            for (ui_player, mut unit_ui_repr, children) in player_unit_ui.iter_mut() {
+                if cursor_player != ui_player {
+                    continue;
+                }
+
+                match unit {
+                    Some(..) => *unit_ui_repr = Visibility::Visible,
+                    None => *unit_ui_repr = Visibility::Hidden,
+                };
+
+                // If there is a unit, we need to update the now visible UI
+                let Some((unit, phase_resources)) = unit else {
+                    continue;
+                };
+
+                for child in children {
+                    if let Some(mut text) = player_ui_health_text.get_mut(*child).ok() {
+                        text.0 = PlayerUiHealthText::derive_text(&unit);
+                    } else if let Some(mut text) = player_ui_name_text.get_mut(*child).ok() {
+                        text.0 = PlayerUiNameText::derive_text(&unit);
+                    } else if let Some(mut text) = player_ui_move_text.get_mut(*child).ok() {
+                        text.0 = format!("Move: {}", phase_resources.movement_points_left_in_phase);
+                    } else if let Some(mut text) = player_ui_ap_text.get_mut(*child).ok() {
+                        text.0 = format!("AP: {}", phase_resources.action_points_left_in_phase);
+                    }
                 }
             }
         }
     }
-}
 
-#[derive(Component)]
-pub struct ActiveBattleMenu {
-    selected_unit: Entity,
-}
+    /// Kind of a silly trait I made when I thought it would be better to make these systems
+    /// generic instead of all in one system.
+    ///
+    /// Leaving them around for now in case I change my mind.
+    pub trait TextFromUnit: Component {
+        fn derive_text(unit: &Unit) -> String;
 
-/// Likely will want to have this spawn the set of options based
-/// on the Unit
-pub fn activate_battle_ui(
-    mut commands: Commands,
-    mut unit_selected: MessageReader<UnitSelectionMessage>,
-    _grid_manager: Res<GridManagerResource>,
-    mut player_battle_menu: Query<
-        (Entity, &player::Player, &mut Visibility, &mut GameMenuGrid),
-        With<BattlePlayerUI>,
-    >,
-) {
-    for message in unit_selected.read() {
-        for (player_grid_menu, player, mut vis, mut menu) in player_battle_menu.iter_mut() {
-            if *player != message.player {
-                continue;
-            }
+        fn update(unit: &Unit, to_update: &mut Text) {
+            to_update.0 = Self::derive_text(unit);
+        }
+    }
 
-            menu.reset_menu_option();
-            commands.entity(player_grid_menu).insert((
-                ActiveMenu {},
-                ActiveBattleMenu {
-                    selected_unit: message.entity,
-                },
-            ));
-            *vis = Visibility::Visible;
+    impl TextFromUnit for PlayerUiHealthText {
+        fn derive_text(unit: &Unit) -> String {
+            format!("HP: {}/{}", unit.stats.health, unit.stats.max_health)
+        }
+    }
+
+    impl TextFromUnit for PlayerUiNameText {
+        fn derive_text(unit: &Unit) -> String {
+            unit.name.clone()
         }
     }
 }
 
-// TODO: Should I support touching with le mouse?
-pub fn handle_battle_ui_interactions(
-    mut commands: Commands,
-    player_input_query: Query<(&Player, &ActionState<PlayerInputAction>)>,
-    mut player_battle_menu: Query<
-        (
-            Entity,
-            &ActiveBattleMenu,
-            &mut GameMenuGrid,
-            &GameMenuController,
-            &mut Visibility,
-        ),
-        With<ActiveMenu>,
-    >,
-    unit_menu_query: Query<&UnitMenuAction>,
-    mut battle_command_writer: MessageWriter<UnitUiCommandMessage>,
-) {
-    for (player, input_actions) in player_input_query.iter() {
-        for (battle_menu_e, battle_menu, menu, controller, mut visibility) in
-            player_battle_menu.iter_mut()
-        {
-            if !controller.players.contains(player) {
+/// Systems that update a given player's "BattleUI"
+///
+/// This UI allows the user to pick what they want a unit to do.
+pub mod player_battle_ui_systems {
+
+    use super::*;
+
+    /// An ActiveBattleMenu component
+    ///
+    /// Primarily used to communicate to the menu what unit was selected.
+    #[derive(Component, Clone)]
+    pub struct ActiveBattleMenu {
+        selected_unit: Entity,
+    }
+
+    /// Marker component for whether or not this menu has an open "child" menu.
+    ///
+    /// While our level of nesting in the BattleUI is currently fixed, this
+    /// marker component gives us a way of referencing our parent, and let's things in the
+    /// battle ui system be fairly general.
+    #[derive(Component)]
+    pub struct NestedDynamicMenu {
+        parent: Entity,
+    }
+
+    /// If the player has selected a terminal node in the BattleUi, but then clicks back
+    /// we use this handler to reactivate the battle menu, without clearing the previous state.
+    pub fn reactivate_ui_on_back_message(
+        mut commands: Commands,
+        mut message_reader: MessageReader<UnitSelectionBackMessage>,
+        mut battle_container_ui: Query<
+            (&player::Player, &mut Visibility, &Children),
+            (With<BattleUiContainer>, Without<BattlePlayerUI>),
+        >,
+        nested_dynamic: Query<Option<&NestedDynamicMenu>>,
+    ) {
+        for message in message_reader.read() {
+            let Some((_, mut vis, children)) = battle_container_ui
+                .iter_mut()
+                .filter(|(p, _, _)| **p == message.player)
+                .next()
+            else {
+                warn!(
+                    "No BattleUiContainer found for player: {:?}",
+                    message.player
+                );
                 continue;
+            };
+
+            *vis = Visibility::Visible;
+            let mut target = children.first().cloned();
+            for child in children.iter().rev() {
+                if let Some(_) = nested_dynamic.get(child).ok().flatten() {
+                    target = Some(child);
+                    break;
+                }
             }
+
+            if let Some(target) = target {
+                commands.entity(target).insert(ActiveMenu {});
+            }
+        }
+    }
+
+    /// Activate the Battle UI
+    pub fn activate_battle_ui(
+        mut commands: Commands,
+        mut unit_selected: MessageReader<UnitSelectionMessage>,
+        _grid_manager: Res<GridManagerResource>,
+        mut player_battle_menu: Query<
+            (Entity, &player::Player, &mut Visibility, &mut GameMenuGrid),
+            With<BattlePlayerUI>,
+        >,
+        mut battle_container_ui: Query<
+            (&player::Player, &mut Visibility),
+            (With<BattleUiContainer>, Without<BattlePlayerUI>),
+        >,
+    ) {
+        for message in unit_selected.read() {
+            for (player_grid_menu, player, mut vis, mut menu) in player_battle_menu.iter_mut() {
+                if *player != message.player {
+                    continue;
+                }
+
+                menu.reset_menu_option();
+
+                commands.entity(player_grid_menu).insert((
+                    ActiveMenu {},
+                    ActiveBattleMenu {
+                        selected_unit: message.entity,
+                    },
+                ));
+                *vis = Visibility::Inherited;
+            }
+
+            if let Some((_, mut vis)) = battle_container_ui
+                .iter_mut()
+                .filter(|(p, _)| **p == message.player)
+                .next()
+            {
+                *vis = Visibility::Visible;
+            }
+        }
+    }
+
+    /// Utility function for cleaning up a stale skill menu
+    fn clean_stale_menu(commands: &mut Commands, menu_e: Entity, vis: &mut Visibility) {
+        let mut skill_menu = commands.entity(menu_e);
+        skill_menu.despawn_children();
+        skill_menu.remove::<(
+            GameMenuGrid,
+            ActiveBattleMenu,
+            NestedDynamicMenu,
+            ActiveMenu,
+        )>();
+        *vis = Visibility::Hidden;
+    }
+
+    /// Clear out potentially stale skill systems when the Battle UI is activated
+    ///
+    /// TODO: I don't love that this uses UnitSelectionMessage, as opposed to
+    /// having a specific event coming off the BattleUI.a
+    pub fn clear_stale_battle_menus_on_activate(
+        mut commands: Commands,
+        mut unit_selected: MessageReader<UnitSelectionMessage>,
+        mut skill_menu_query: Query<(Entity, &Player, &mut Visibility), With<SkillMenu>>,
+        mut skill_menu_category_query: Query<
+            (Entity, &Player, &mut Visibility),
+            (With<SkillsFilteredByCategoryMenu>, Without<SkillMenu>),
+        >,
+    ) {
+        for message in unit_selected.read() {
+            for (e, p, mut vis) in skill_menu_query.iter_mut() {
+                if *p != message.player {
+                    continue;
+                }
+                clean_stale_menu(&mut commands, e, &mut vis);
+            }
+
+            for (e, p, mut vis) in skill_menu_category_query.iter_mut() {
+                if *p != message.player {
+                    continue;
+                }
+                clean_stale_menu(&mut commands, e, &mut vis);
+            }
+        }
+    }
+
+    /// If we send a command to the Unit, set the UI to invisible so they can make their pick without the UI
+    /// getting in their way
+    pub fn hide_battle_ui_on_unit_ui_command(
+        mut query: Query<(&Player, &mut Visibility), With<BattleUiContainer>>,
+        mut unit_command_message: MessageReader<UnitUiCommandMessage>,
+    ) {
+        for message in unit_command_message.read() {
+            if let Some((_, mut vis)) = query
+                .iter_mut()
+                .filter(|(p, _)| **p == message.player)
+                .next()
+            {
+                *vis = Visibility::Hidden;
+            }
+        }
+    }
+
+    /// The set of components that one menu should pass to the next.
+    #[derive(Bundle)]
+    struct SkillMenuHandMeDowns {
+        battle_menu: ActiveBattleMenu,
+        controller: GameMenuController,
+        nested: NestedDynamicMenu,
+    }
+
+    fn initialize_skill_menu(
+        commands: &mut Commands,
+        skill_menu_entity: Entity,
+        buttons: Vec<Entity>,
+        vis: &mut Visibility,
+        hand_me_downs: SkillMenuHandMeDowns,
+    ) {
+        let mut skill_menu_e = commands.entity(skill_menu_entity);
+        skill_menu_e.add_children(buttons.as_slice());
+        let mut menu = GameMenuGrid::new_vertical();
+        menu.push_buttons_to_stack(buttons.as_slice());
+        skill_menu_e.insert((hand_me_downs, menu, ActiveMenu {}));
+
+        *vis = Visibility::Inherited;
+    }
+
+    /// The chonky function that handles most of the logic here.
+    ///
+    /// Sends out UnitUiCommandMessages, or manages sub menus when a player clicks
+    /// select or deselect, based on the current state.
+    ///
+    /// We use the With<ActiveMenu> tag for operating on only one of our menus at a time,
+    /// and the skill_menu_*_querys for giving sub menus focus and visibility. We also maintain a
+    /// NestedDynamicMenu primarily for telling if we are the root menu or not.
+    ///
+    /// TODO: Could split this into one query on ActiveMenu that handles Select / Deselect
+    /// and then another that handles what to with a given Action being pressed?
+    pub fn handle_battle_ui_interactions(
+        mut commands: Commands,
+        fonts: Res<FontResource>,
+        player_input_query: Query<(&Player, &ActionState<PlayerInputAction>)>,
+        mut player_battle_menu: Query<
+            (
+                Entity,
+                &ActiveBattleMenu,
+                &mut GameMenuGrid,
+                &GameMenuController,
+                &mut Visibility,
+                Option<&NestedDynamicMenu>,
+            ),
+            With<ActiveMenu>,
+        >,
+        unit_menu_query: Query<&BattleMenuAction>,
+        mut skill_menu_query: Query<
+            (Entity, &Player, &mut Visibility),
+            (
+                With<SkillMenu>,
+                Without<SkillsFilteredByCategoryMenu>,
+                Without<ActiveMenu>,
+            ),
+        >,
+        mut skill_menu_category_query: Query<
+            (Entity, &Player, &mut Visibility),
+            (
+                With<SkillsFilteredByCategoryMenu>,
+                Without<SkillMenu>,
+                Without<ActiveMenu>,
+            ),
+        >,
+        mut battle_command_writer: MessageWriter<UnitUiCommandMessage>,
+    ) {
+        for (player, input_actions) in player_input_query.iter() {
+            let Some((battle_menu_e, battle_menu, menu, controller, mut visibility, nested)) =
+                player_battle_menu
+                    .iter_mut()
+                    .filter(|(_, _, _, controller, _, _)| controller.players.contains(player))
+                    .next()
+            else {
+                continue;
+            };
 
             // Player confirms
             if input_actions.just_pressed(&PlayerInputAction::Select) {
@@ -505,99 +825,126 @@ pub fn handle_battle_ui_interactions(
                     continue;
                 };
 
-                battle_command_writer.write(UnitUiCommandMessage {
-                    player: *player,
-                    command: match menu_option {
-                        UnitMenuAction::Move => UnitCommand::Move,
-                        UnitMenuAction::Attack => UnitCommand::Attack,
-                        UnitMenuAction::Wait => UnitCommand::Wait,
-                    },
-                    unit: battle_menu.selected_unit,
-                });
+                // Spawn a ChildMenu with Menu Options? Set that as the ActiveMenu with a Reference for this Player?
+                // So then a Cancel goes back to
+                match menu_option {
+                    BattleMenuAction::Action(action) => {
+                        battle_command_writer.write(UnitUiCommandMessage {
+                            player: *player,
+                            command: match action {
+                                UnitMenuAction::Move => UnitCommand::Move,
+                                UnitMenuAction::Attack => UnitCommand::Attack,
+                                UnitMenuAction::Wait => UnitCommand::Wait,
+                                UnitMenuAction::UseSkill(skill_id) => {
+                                    log::info!(
+                                        "Player tried to use a Skill with id {:?}! That's cute!",
+                                        skill_id
+                                    );
+                                    continue;
+                                }
+                            },
+                            unit: battle_menu.selected_unit,
+                        });
+                        commands.entity(battle_menu_e).remove::<ActiveMenu>();
+                    }
+                    BattleMenuAction::OpenSkillMenu => {
+                        // Should only be one Menu per player
+                        let Some((skill_menu, _, mut vis)) = skill_menu_query
+                            .iter_mut()
+                            .filter(|(_, p, _)| *p == player)
+                            .next()
+                        else {
+                            continue;
+                        };
+                        // Create button
+                        let attack_button = commands
+                            .spawn(battle_ui_button(
+                                &fonts,
+                                BattleMenuAction::Action(UnitMenuAction::Attack),
+                                "Attack",
+                            ))
+                            .id();
 
-                *visibility = Visibility::Hidden;
-                commands.entity(battle_menu_e).remove::<ActiveMenu>();
+                        // TODO: Pull from Unit somehow?
+                        let skill_category_button = commands
+                            .spawn(battle_ui_button(
+                                &fonts,
+                                BattleMenuAction::OpenSkillsFilteredByCategoryMenu(
+                                    skills::SkillCategoryId::new(),
+                                ),
+                                "Holy Magic",
+                            ))
+                            .id();
+
+                        initialize_skill_menu(
+                            &mut commands,
+                            skill_menu,
+                            vec![attack_button, skill_category_button],
+                            &mut vis,
+                            SkillMenuHandMeDowns {
+                                battle_menu: battle_menu.to_owned(),
+                                controller: controller.to_owned(),
+                                nested: NestedDynamicMenu {
+                                    parent: battle_menu_e,
+                                },
+                            },
+                        );
+
+                        commands.entity(battle_menu_e).remove::<ActiveMenu>();
+                    }
+                    BattleMenuAction::OpenSkillsFilteredByCategoryMenu(_selected_category) => {
+                        let Some((skill_menu_category, _, mut vis)) = skill_menu_category_query
+                            .iter_mut()
+                            .filter(|(_, p, _)| *p == player)
+                            .next()
+                        else {
+                            continue;
+                        };
+
+                        // Create button
+                        let skill_button = commands
+                            .spawn(battle_ui_button(
+                                &fonts,
+                                BattleMenuAction::Action(UnitMenuAction::UseSkill(
+                                    skills::SkillId::new(),
+                                )),
+                                "Holy Strike",
+                            ))
+                            .id();
+
+                        initialize_skill_menu(
+                            &mut commands,
+                            skill_menu_category,
+                            vec![skill_button],
+                            &mut vis,
+                            SkillMenuHandMeDowns {
+                                battle_menu: battle_menu.to_owned(),
+                                controller: controller.to_owned(),
+                                nested: NestedDynamicMenu {
+                                    parent: battle_menu_e,
+                                },
+                            },
+                        );
+
+                        commands.entity(battle_menu_e).remove::<ActiveMenu>();
+                    }
+                }
             } else if input_actions.just_pressed(&PlayerInputAction::Deselect) {
-                // Turn off the Battle Menu, unlock cursor
-                battle_command_writer.write(UnitUiCommandMessage {
-                    player: *player,
-                    command: UnitCommand::Cancel,
-                    unit: battle_menu.selected_unit,
-                });
+                if let Some(dynamic_menu) = nested {
+                    let parent = dynamic_menu.parent;
+                    clean_stale_menu(&mut commands, battle_menu_e, &mut visibility);
+                    commands.entity(parent).insert(ActiveMenu {});
+                } else {
+                    // Turn off the Battle Menu, and unlock the unit's cursor
+                    battle_command_writer.write(UnitUiCommandMessage {
+                        player: *player,
+                        command: UnitCommand::Cancel,
+                        unit: battle_menu.selected_unit,
+                    });
 
-                *visibility = Visibility::Hidden;
-
-                commands.entity(battle_menu_e).remove::<ActiveMenu>();
-            }
-        }
-    }
-}
-
-mod unused_experiments {
-    use super::*;
-
-    pub fn update_text_from_unit_under_cursor<T: TextFromUnit>(
-        grid_manager: Res<grid::GridManagerResource>,
-        cursor_query: Query<
-            (&player::Player, &grid::GridPosition),
-            (With<Cursor>, Changed<grid::GridPosition>),
-        >,
-        unit_query: Query<&Unit>,
-        mut text_query: Query<(&player::Player, &mut Text), With<T>>,
-    ) {
-        for (cursor_player, grid_pos) in cursor_query.iter() {
-            let Some(entities) = grid_manager.grid_manager.get_by_position(grid_pos) else {
-                continue;
-            };
-
-            let unit = entities
-                .iter()
-                .filter_map(|t| unit_query.get(*t).ok())
-                .next();
-
-            // If there is a unit, we need to update the now visible UI
-            let Some(unit) = unit else {
-                continue;
-            };
-
-            for (ui_player, mut text) in text_query.iter_mut() {
-                if cursor_player != ui_player {
-                    continue;
+                    *visibility = Visibility::Hidden;
+                    commands.entity(battle_menu_e).remove::<ActiveMenu>();
                 }
-
-                text.0 = T::derive_text(unit);
-            }
-        }
-    }
-
-    pub fn update_player_ui_visibility(
-        grid_manager: Res<grid::GridManagerResource>,
-        cursor_query: Query<
-            (&player::Player, &grid::GridPosition),
-            (With<Cursor>, Changed<grid::GridPosition>),
-        >,
-        unit_query: Query<&Unit>,
-        mut player_ui_unit_visible: Query<(&player::Player, &mut Visibility), With<PlayerUiInfo>>,
-    ) {
-        for (cursor_player, grid_pos) in cursor_query.iter() {
-            let Some(entities) = grid_manager.grid_manager.get_by_position(grid_pos) else {
-                continue;
-            };
-
-            let unit = entities
-                .iter()
-                .filter_map(|t| unit_query.get(*t).ok())
-                .next();
-
-            for (ui_player, mut unit_ui_repr) in player_ui_unit_visible.iter_mut() {
-                if cursor_player != ui_player {
-                    continue;
-                }
-
-                match unit {
-                    Some(..) => *unit_ui_repr = Visibility::Visible,
-                    None => *unit_ui_repr = Visibility::Hidden,
-                };
             }
         }
     }

--- a/src/battle_phase.rs
+++ b/src/battle_phase.rs
@@ -180,7 +180,7 @@ pub fn start_phase(
 pub mod phase_ui {
     use bevy::prelude::*;
 
-    use crate::{assets::FontResource, battle_phase::PlayerEnemyPhase};
+    use crate::{assets::FontResource, battle::BattleEntity, battle_phase::PlayerEnemyPhase};
 
     #[derive(Debug)]
     pub enum BattleBannerMessage {
@@ -230,11 +230,12 @@ pub mod phase_ui {
                     timer: Timer::from_seconds(0.4, TimerMode::Once),
                     state: BannerAnimState::Entering,
                 },
+                BattleEntity {},
             ))
             .id();
 
-        let blue = Color::linear_rgba(0.2, 0.2, 0.95, 1.0);
-        let red = Color::linear_rgba(0.9, 0.35, 0.4, 1.0);
+        let blue = Color::linear_rgba(0.0, 0.0, 1.0, 1.0);
+        let red = Color::linear_rgba(1.0, 0.0, 0.0, 1.0);
 
         let (color, text) = match &event.message {
             BattleBannerMessage::PhaseBegin(phase) => match phase {
@@ -253,13 +254,13 @@ pub mod phase_ui {
                     ..Default::default()
                 },
                 BorderRadius::all(percent(20)),
-                BackgroundColor(Color::linear_rgba(0.4, 0.4, 0.4, 0.8)),
+                BackgroundColor(Color::linear_rgba(0.7, 0.7, 0.7, 0.8)),
                 children![(
                     TextColor(color),
                     Text::new(text),
                     TextFont {
                         font_size: 60.,
-                        font: fonts.fine_fantasy.clone(),
+                        font: fonts.badge.clone(),
                         ..Default::default()
                     },
                 )],

--- a/src/combat.rs
+++ b/src/combat.rs
@@ -152,3 +152,24 @@ pub fn attack_execution_despawner(
         }
     }
 }
+
+/// I haven't actually thought about this at all, just trying to build some UIs
+pub mod skills {
+    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+    pub struct SkillCategoryId(u32);
+
+    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+    pub struct SkillId(u32);
+
+    impl SkillId {
+        pub fn new() -> Self {
+            SkillId(0)
+        }
+    }
+
+    impl SkillCategoryId {
+        pub fn new() -> Self {
+            SkillCategoryId(0)
+        }
+    }
+}


### PR DESCRIPTION
I want to be able to pick skills in a menu! Let's create a nested battle menu
that's capable of finding the information we want about a unit (once we have that information).

In order to get things to overlap in the way I want, I had to switch to using CSS Grids.
I ended up rewriting the majority of the Battle Menu logic while I was here :shrug:
