### PR TITLE
fix(player-id): Fix Player Id resolution

### DIFF
--- a/src/battle.rs
+++ b/src/battle.rs
@@ -462,7 +462,7 @@ pub fn spawn_battle_resolution_ui(
         .spawn((
             battle_resolution_menu,
             menu_navigation::GameMenuController {
-                players: HashSet::from([Player::One, Player::Two]),
+                players: HashSet::from([Player::PrePlayer]),
             },
             ActiveMenu {},
             GameMenuLatch::default(),

--- a/src/join_game_menu.rs
+++ b/src/join_game_menu.rs
@@ -508,13 +508,14 @@ fn join_game(
     let player = if players_count >= 4 {
         anyhow::bail!("Maximum number of players reached.");
     } else {
-        match players_count {
-            0 => Player::One,
-            1 => Player::Two,
-            2 => Player::Three,
-            3 => Player::Four,
-            _ => unreachable!(),
-        }
+        let max_player_id = joined_players
+            .0
+            .keys()
+            .map(|t| t.id())
+            .max()
+            .unwrap_or_default();
+
+        Player::PlayerId(max_player_id + 1)
     };
 
     let input_map = match controller {

--- a/src/player.rs
+++ b/src/player.rs
@@ -13,16 +13,20 @@ use crate::{
     unit::{AttackOption, ValidMove},
 };
 
-// TODO: Probably want this to be more like "PlayerId(u32)"
-// Although we probably could just make it 1, 2, 3, 4...
 #[derive(Component, Reflect, PartialEq, Eq, Hash, Debug, Copy, Clone)]
 pub enum Player {
-    One,
-    Two,
-    Three,
-    Four,
+    PlayerId(u32),
     /// This is a catch all player that exists before other players. Meta, I know
     PrePlayer,
+}
+
+impl Player {
+    pub fn id(&self) -> u32 {
+        match self {
+            Player::PlayerId(id) => *id,
+            Player::PrePlayer => 0,
+        }
+    }
 }
 
 #[derive(Bundle)]
@@ -45,7 +49,7 @@ impl PlayerBundle {
 impl Player {
     pub fn get_keyboard_input_map(&self) -> InputMap<PlayerInputAction> {
         match self {
-            Player::One => InputMap::new([
+            Player::PlayerId(..) => InputMap::new([
                 (PlayerInputAction::MoveCursorUp, KeyCode::KeyW),
                 (PlayerInputAction::MoveCursorDown, KeyCode::KeyS),
                 (PlayerInputAction::MoveCursorLeft, KeyCode::KeyA),
@@ -54,14 +58,6 @@ impl Player {
                 (PlayerInputAction::Deselect, KeyCode::ShiftLeft),
                 (PlayerInputAction::ZoomIn, KeyCode::KeyQ),
                 (PlayerInputAction::ZoomOut, KeyCode::KeyE),
-            ]),
-            Player::Two | Player::Three | Player::Four => InputMap::new([
-                (PlayerInputAction::MoveCursorUp, KeyCode::ArrowUp),
-                (PlayerInputAction::MoveCursorDown, KeyCode::ArrowDown),
-                (PlayerInputAction::MoveCursorLeft, KeyCode::ArrowLeft),
-                (PlayerInputAction::MoveCursorRight, KeyCode::ArrowRight),
-                (PlayerInputAction::Select, KeyCode::Enter),
-                (PlayerInputAction::Deselect, KeyCode::ShiftRight),
             ]),
 
             Player::PrePlayer => {

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -1303,7 +1303,7 @@ mod tests {
         });
         app.insert_resource::<Time>(Time::default());
         app.insert_resource(PlayerGameStates {
-            player_state: HashMap::from([(Player::One, PlayerState::default())]),
+            player_state: HashMap::from([(Player::PlayerId(1), PlayerState::default())]),
         });
         app.add_plugins(InputManagerPlugin::<PlayerInputAction>::default());
         app
@@ -1314,10 +1314,12 @@ mod tests {
         init_logger();
         let mut app = create_test_app();
 
+        let player = Player::PlayerId(1);
+
         // Spawn player to handle movement events
         let player_entity = app
             .world_mut()
-            .spawn(player::PlayerBundle::new(Player::One))
+            .spawn(player::PlayerBundle::new(player))
             .id();
         let unit_entity = app
             .world_mut()
@@ -1329,7 +1331,7 @@ mod tests {
                     obstacle: crate::unit::ObstacleType::Filter(HashSet::from([PLAYER_TEAM])),
                     name: "Bob".to_string(),
                 },
-                Player::One,
+                player,
                 GridPosition { x: 2, y: 2 },
                 Transform::default(),
                 UnitPhaseResources::default(),
@@ -1339,11 +1341,7 @@ mod tests {
         // Spawn a cursor at (2, 2) for Player::One
         let cursor_entity = app
             .world_mut()
-            .spawn((
-                grid_cursor::Cursor {},
-                Player::One,
-                GridPosition { x: 2, y: 2 },
-            ))
+            .spawn((grid_cursor::Cursor {}, player, GridPosition { x: 2, y: 2 }))
             .id();
 
         // Setup the phase system
@@ -1380,7 +1378,7 @@ mod tests {
         // move.
         app.world_mut().write_message(UnitUiCommandMessage {
             unit: unit_entity,
-            player: Player::One,
+            player,
             command: UnitCommand::Move,
         });
 


### PR DESCRIPTION
In the join game menu, we were naively choosing a variant of an enum
based on the number of players that were currently joined. If two
players joined, and then the first player left, the next joining
player would incorrectly be assigned `Player::Two`. There's really not
a great reason for using enums here. I mostly was just following an
example when I added them. Let's make our player's use increasing ids
instead.

Note that technically there's a risk of u32 overflow if we added and
removed players a bunch, but seems like a fine time for the game to
crash to me.
