### PR TITLE
feat(combat): Implement stun mechanic, skip turns and block actions for stunned units

### DIFF
--- a/src/battle.rs
+++ b/src/battle.rs
@@ -36,8 +36,9 @@ use crate::{
     battle_phase::{
         PhaseMessage, StartOfPhaseEffectsMessage, TurnStartMessage,
         advance_after_start_of_phase_effects, check_for_active_effect_damage_on_turn_start,
-        check_should_advance_phase, decrement_turn_count_effects_on_turn_start, init_phase_system,
-        is_enemy_phase, is_running_enemy_phase, is_running_player_phase,
+        check_for_stun_on_turn_start, check_should_advance_phase,
+        decrement_turn_count_effects_on_turn_start, init_phase_system, is_enemy_phase,
+        is_running_enemy_phase, is_running_player_phase,
         phase_ui::{
             BattlePhaseMessageComplete, ShowBattleBannerMessage, banner_animation_system,
             spawn_banner_system,
@@ -216,6 +217,8 @@ pub fn battle_plugin(app: &mut App) {
                 decrement_turn_count_effects_on_turn_start::<Enemy>,
                 check_for_active_effect_damage_on_turn_start::<Player>,
                 check_for_active_effect_damage_on_turn_start::<Enemy>,
+                check_for_stun_on_turn_start::<Player>,
+                check_for_stun_on_turn_start::<Enemy>,
                 advance_after_start_of_phase_effects,
                 spawn_banner_system,
                 banner_animation_system,

--- a/src/battle_phase.rs
+++ b/src/battle_phase.rs
@@ -244,6 +244,25 @@ pub fn check_for_active_effect_damage_on_turn_start<T: PhaseSystem<PlayerEnemyPh
     }
 }
 
+pub fn check_for_stun_on_turn_start<T: PhaseSystem<PlayerEnemyPhase>>(
+    mut message_reader: MessageReader<StartOfPhaseEffectsMessage>,
+    mut query: Query<(&ActiveEffects, &mut UnitPhaseResources), With<T::Marker>>,
+) {
+    for message in message_reader.read() {
+        if message.phase != T::OWNED_PHASE {
+            continue;
+        }
+
+        for (active_effects, mut phase_resources) in query.iter_mut() {
+            if active_effects.statuses().contains(&StatusTag::Stunned) {
+                phase_resources.action_points_left_in_phase = 0;
+                phase_resources.movement_points_left_in_phase = 0;
+                phase_resources.waited = true;
+            }
+        }
+    }
+}
+
 #[derive(Component)]
 struct PoisonDamageEntity;
 

--- a/src/combat.rs
+++ b/src/combat.rs
@@ -1685,7 +1685,10 @@ pub mod skills {
                             advancing_event: SkillEvent::ProjectileImpact(SkillAnimationId(1)),
                         },
                         SkillStage {
-                            stage: SkillStageAction::Impact(vec![SkillActionIndex(0)]),
+                            stage: SkillStageAction::Impact(vec![
+                                SkillActionIndex(0),
+                                SkillActionIndex(1),
+                            ]),
                             advancing_event: SkillEvent::ProjectileImpact(SkillAnimationId(1)),
                         },
                     ],


### PR DESCRIPTION
Adds full stun behavior so that stunned units lose their turn entirely.

Disclaimer: this could be slop, it was 100% generated by AI.