### PR TITLE
fix(battle-menu): Always set player active menu on player phase start

### DIFF
--- a/src/battle.rs
+++ b/src/battle.rs
@@ -28,7 +28,7 @@ use crate::{
         player_battle_ui_systems::{
             activate_battle_ui, clear_stale_battle_menus_on_activate, close_player_battle_menus,
             handle_battle_ui_interactions, on_unit_completed_action_reopen_battle_menu,
-            reactivate_ui_on_back_message, set_active_battle_menu,
+            reactivate_ui_on_back_message, set_active_battle_menu_on_player_turn,
         },
         player_info_ui_systems::update_unit_viewer_ui,
         update_controlled_ui_info,
@@ -204,11 +204,7 @@ pub fn battle_plugin(app: &mut App) {
         .add_systems(OnEnter(DungeonState::LoadRoom), load_room)
         .add_systems(
             OnEnter(DungeonState::InBattle),
-            (
-                equip_starting_items_on_unit,
-                init_phase_system,
-                set_active_battle_menu,
-            ),
+            (equip_starting_items_on_unit, init_phase_system),
         )
         .add_systems(OnEnter(DungeonState::UnloadRoom), unload_room)
         .add_systems(
@@ -216,6 +212,10 @@ pub fn battle_plugin(app: &mut App) {
             (handle_stat_changes, derive_stats)
                 .chain()
                 .run_if(in_state(DungeonState::InBattle)),
+        )
+        .add_systems(
+            Update,
+            (set_active_battle_menu_on_player_turn).run_if(in_state(DungeonState::InBattle)),
         )
         .add_systems(
             Update,

--- a/src/battle_menu.rs
+++ b/src/battle_menu.rs
@@ -714,6 +714,7 @@ pub mod player_battle_ui_systems {
 
     use crate::{
         assets::sounds::{SoundManagerParam, UiSound},
+        battle_phase::{PhaseMessage, PhaseMessageType, PlayerEnemyPhase},
         combat::skills::{ATTACK_SKILL_ID, SkillDBResource, UnitSkills},
         equipment::UnitEquipment,
         grid::GridPosition,
@@ -879,20 +880,27 @@ pub mod player_battle_ui_systems {
 
     /// At the moment a player has exactly one Unit on the board.
     /// This system links the UI that the player will get to that entity.
-    pub fn set_active_battle_menu(
+    pub fn set_active_battle_menu_on_player_turn(
         mut commands: Commands,
+        mut reader: MessageReader<PhaseMessage>,
         player_units: Query<(Entity, &Player), With<Unit>>,
         battle_menus: Query<(Entity, &Player), With<BattlePlayerUI>>,
     ) {
-        for (e, player) in player_units {
-            for (battle_menu_e, battle_player) in battle_menus {
-                if player != battle_player {
-                    continue;
-                }
+        for message in reader.read() {
+            let PhaseMessageType::PhaseBegin(PlayerEnemyPhase::Player) = message.0 else {
+                continue;
+            };
 
-                commands
-                    .entity(battle_menu_e)
-                    .insert((ActiveBattleMenu { selected_unit: e }, ActiveMenu {}));
+            for (e, player) in player_units {
+                for (battle_menu_e, battle_player) in battle_menus {
+                    if player != battle_player {
+                        continue;
+                    }
+
+                    commands
+                        .entity(battle_menu_e)
+                        .insert((ActiveBattleMenu { selected_unit: e }, ActiveMenu {}));
+                }
             }
         }
     }
@@ -1050,6 +1058,7 @@ pub mod player_battle_ui_systems {
                             },
                             unit: battle_menu.selected_unit,
                         });
+                        info!("I am removing the active menu for {:?}", battle_menu_e);
                         commands.entity(battle_menu_e).remove::<ActiveMenu>();
                     }
                     BattleMenuAction::OpenSkillMenu => {


### PR DESCRIPTION
We keep seeing this weird issue that I don't understand as documented
in [1]. Until we can root cause what's wrong with that, let's patch
over this by always opening the menu to avoid the soft lock.

[1]: https://github.com/BKDaugherty/couch-tactics/issues/60